### PR TITLE
Add Graphite CI Optimization

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,20 @@ on:
     branches: [main]
 
 jobs:
+  optimize_ci:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@main
+        with:
+          graphite_token: ${{ secrets.GRAPHITE }}
+
   test:
+    needs: optimize_ci
+    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### TL;DR
Added Graphite CI optimization to the GitHub Actions workflow

### What changed?
- Integrated the Graphite CI action to optimize test execution
- Added a new `optimize_ci` job that runs before the test job
- Made the test job conditional based on Graphite's optimization output
- Configured the workflow to use a Graphite token for authentication

### How to test?
1. Push a commit to the main branch
2. Verify that the Graphite CI optimization job runs first
3. Confirm that the test job only runs when Graphite determines it's necessary
4. Check that the Graphite token is properly configured in repository secrets

### Why make this change?
To improve CI efficiency by intelligently skipping unnecessary test runs based on Graphite's analysis of code changes, reducing build times and computational resources.