### PR TITLE
Adds a leaderboard to the game!

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -56,6 +56,23 @@ class WordleApp < Sinatra::Base
     }
   end
 
+  get '/leaderboard' do
+    # Get top 10 players by number of wins
+    top_players = Game.select('COUNT(*) as wins')
+      .where("guesses @> '[{\"result\":[\"correct\",\"correct\",\"correct\",\"correct\",\"correct\"]}]'")
+      .group('user_id')
+      .order('wins DESC')
+      .limit(10)
+      .map do |result|
+        {
+          user: User.find(result.user_id),
+          wins: result.wins
+        }
+      end
+
+    erb :leaderboard, locals: { players: top_players }
+  end
+
   # Start the application if ruby file executed directly
   run! if app_file == $0
 end


### PR DESCRIPTION
### TL;DR
Added a leaderboard endpoint and configured GitHub Actions to use Ubuntu runner

### What changed?
- Added a new `/leaderboard` endpoint that displays top 10 players by wins
- Set GitHub Actions runner to `ubuntu-latest` instead of placeholder value
- Implemented leaderboard query to count successful Wordle completions per user

### How to test?
1. Visit `/leaderboard` endpoint
2. Verify top 10 players are displayed with their win counts
3. Confirm GitHub Actions workflow runs successfully on `ubuntu-latest`

### Why make this change?
Adds competitive element to the game by allowing players to see how they rank against others, while also properly configuring the CI environment for automated testing